### PR TITLE
Fix for issue #25: invalid content type header

### DIFF
--- a/mod_upload_progress.c
+++ b/mod_upload_progress.c
@@ -708,7 +708,7 @@ static int reportuploads_handler(request_rec *r)
     }
     CACHE_UNLOCK();
 
-    ap_set_content_type(r, "text/javascript");
+    ap_set_content_type(r, "application/json");
 
     apr_table_set(r->headers_out, "Expires", "Mon, 28 Sep 1970 06:00:00 GMT");
     apr_table_set(r->headers_out, "Cache-Control", "no-cache");


### PR DESCRIPTION
I agree with the issue creator on that as the content returned is not javascript but json, the content-type has to be fixed to conform to the return data type. 
I've fixed the content-type from 'text/javascript' to 'application/json' so if you agree with that position, I'd be glad if you accepted my pull request.
