### PR TITLE
Unlink previous cache file for additional safety during init

### DIFF
--- a/mod_upload_progress.c
+++ b/mod_upload_progress.c
@@ -533,6 +533,7 @@ static apr_status_t upload_progress_cache_init(apr_pool_t *pool, ServerConfig *c
     if (config->cache_file) {
         /* Remove any existing shm segment with this name. */
         apr_shm_remove(config->cache_file, pool);
+        unlink(config->cache_file);
     }
 
     size = APR_ALIGN_DEFAULT(config->cache_bytes);


### PR DESCRIPTION
On Debian 11 (bullseye), apache can fail to reload (after nightly log rotation, for example) with the following message in `error.log`:

```
[Tue Jan 04 00:00:01.109918 2022] [:error] [pid 2876161] (17)File exists: Upload Progress cache: could not create shared memory segment
[Tue Jan 04 00:00:01.109952 2022] [:emerg] [pid 2876161] AH00020: Configuration Failed, exiting
```

This PR unlinks the previous upload progress cache, if any, during initialization. This, combined with [disabling PrivateTmp](https://stackoverflow.com/questions/68098031/how-to-set-privatetmp-false-permanently-in-ubuntu-18-04) should alleviate this issue.